### PR TITLE
Improving pads (drums and pad components)

### DIFF
--- a/src/components/nodes/index.tsx
+++ b/src/components/nodes/index.tsx
@@ -85,6 +85,7 @@ export type WorkflowNodeData = {
 
   // Beat machine node data
   rows?: Array<{ instrument: string; pattern: boolean[] }>;
+    modifiersEnabled?: boolean;
 
   // Arpeggiator node data
   selectedPattern?: string;

--- a/src/components/nodes/instruments/beat-machine-node.tsx
+++ b/src/components/nodes/instruments/beat-machine-node.tsx
@@ -7,6 +7,7 @@ import { PadButton } from './pad-utils/pad-button';
 import { useAppStore } from '@/store/app-context';
 import { WorkflowNodeProps, AppNode } from '..';
 import { DRUM_OPTIONS } from '@/data/sound-options';
+import { DRUM_CATEGORIES } from '@/data/sound-categories';
 
 interface BeatMachineRow {
   instrument: string;
@@ -58,10 +59,13 @@ function SequencerRow({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {DRUM_OPTIONS.map((sound) => (
-            <SelectItem key={sound} value={sound}>
-              {sound}
-            </SelectItem>
+          {DRUM_CATEGORIES.map((cat) => (
+            <div key={cat.label}>
+              <div className="px-2 py-1 text-xs text-muted-foreground font-semibold">{cat.label}</div>
+              {cat.options.map((sound) => (
+                <SelectItem key={sound} value={sound}>{sound}</SelectItem>
+              ))}
+            </div>
           ))}
         </SelectContent>
       </Select>

--- a/src/components/nodes/instruments/beat-machine-node.tsx
+++ b/src/components/nodes/instruments/beat-machine-node.tsx
@@ -162,12 +162,34 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
     updateNodeData(id, { rows: newRows });
   };
 
+
   const clearAll = () => {
     const newRows = rows.map((row) => ({
       ...row,
       pattern: Array(16).fill(false),
       modifiers: {},
     }));
+    updateNodeData(id, { rows: newRows });
+  };
+
+
+  const addTrack = () => {
+    // Use latest rows from current closure
+    const newRows = [
+      ...rows,
+      {
+        instrument: DRUM_OPTIONS[0] || 'bd',
+        pattern: Array(16).fill(false),
+        modifiers: {},
+      },
+    ];
+    updateNodeData(id, { rows: newRows });
+  };
+
+  // Remove the last track (if more than one)
+  const removeTrack = () => {
+    if (rows.length <= 1) return;
+    const newRows = rows.slice(0, -1);
     updateNodeData(id, { rows: newRows });
   };
 
@@ -187,14 +209,33 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
           ))}
         </div>
         <div className="flex flex-wrap gap-2 items-center justify-between">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={clearAll}
-            className="text-xs"
-          >
-            Clear All
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={clearAll}
+              className="text-xs"
+            >
+              Clear All
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={addTrack}
+              className="text-xs"
+            >
+              + Add Track
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={removeTrack}
+              className="text-xs"
+              disabled={rows.length <= 1}
+            >
+              Remove Track
+            </Button>
+          </div>
         </div>
       </div>
     </WorkflowNode>

--- a/src/components/nodes/instruments/beat-machine-node.tsx
+++ b/src/components/nodes/instruments/beat-machine-node.tsx
@@ -1,17 +1,12 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { CellState, ModifierDropdown } from './pad-utils/modifiers';
 import WorkflowNode from '@/components/nodes/workflow-node';
-import { WorkflowNodeProps, AppNode } from '..';
-import { useAppStore } from '@/store/app-context';
 import { Button } from '@/components/ui/button';
 import { PadButton } from './pad-utils/pad-button';
+import { useAppStore } from '@/store/app-context';
+import { WorkflowNodeProps, AppNode } from '..';
 import { DRUM_OPTIONS } from '@/data/sound-options';
-import { ModifierDropdown, CellState } from './pad-utils/modifiers';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 
 interface BeatMachineRow {
   instrument: string;
@@ -44,12 +39,14 @@ function SequencerRow({
   onStepClick,
   onInstrumentChange,
   onModifierSelect,
+  showModifiers,
 }: {
   row: BeatMachineRow;
   rowIndex: number;
   onStepClick: (rowIndex: number, step: number) => void;
   onInstrumentChange: (rowIndex: number, instrument: string) => void;
   onModifierSelect: (rowIndex: number, stepIdx: number, modifier: CellState) => void;
+  showModifiers: boolean;
 }) {
   return (
     <div className="flex items-center gap-2">
@@ -85,22 +82,24 @@ function SequencerRow({
                 noteGroups={{}}
                 toggleCell={() => onStepClick(rowIndex, step)}
               />
-              <ModifierDropdown
-                currentState={row.modifiers?.[step] || { type: 'off' }}
-                onModifierSelect={(modifier) => onModifierSelect(rowIndex, step, modifier)}
-                modifierGroups={{
-                  Speed: [
-                    { value: '*2', label: '*2' },
-                    { value: '*3', label: '*3' },
-                    { value: '*4', label: '*4' },
-                  ],
-                  Elongate: [
-                    { value: '@2', label: '@2' },
-                    { value: '@3', label: '@3' },
-                    { value: '@4', label: '@4' },
-                  ],
-                }}
-              />
+              {showModifiers && (
+                <ModifierDropdown
+                  currentState={row.modifiers?.[step] || { type: 'off' }}
+                  onModifierSelect={(modifier) => onModifierSelect(rowIndex, step, modifier)}
+                  modifierGroups={{
+                    Speed: [
+                      { value: '*2', label: '*2' },
+                      { value: '*3', label: '*3' },
+                      { value: '*4', label: '*4' },
+                    ],
+                    Elongate: [
+                      { value: '@2', label: '@2' },
+                      { value: '@3', label: '@3' },
+                      { value: '@4', label: '@4' },
+                    ],
+                  }}
+                />
+              )}
             </div>
           );
         })}
@@ -112,19 +111,69 @@ function SequencerRow({
 export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
   const updateNodeData = useAppStore((state) => state.updateNodeData);
 
+  // Modifier toggle state (persisted in node data)
+  const modifiersEnabled = typeof data.modifiersEnabled === 'boolean' ? data.modifiersEnabled : false;
+
+  // Number of steps (default 16)
+  const steps = typeof data.steps === 'number' ? data.steps : 16;
+
   // Use node data directly with defaults
   // Ensure all rows have a 'modifiers' property for type safety
   const rows = (data.rows || [
-    { instrument: 'bd', pattern: Array(16).fill(false), modifiers: {} },
-    { instrument: 'sd', pattern: Array(16).fill(false), modifiers: {} },
-    { instrument: 'hh', pattern: Array(16).fill(false), modifiers: {} },
+    { instrument: 'bd', pattern: Array(steps).fill(false), modifiers: {} },
+    { instrument: 'sd', pattern: Array(steps).fill(false), modifiers: {} },
+    { instrument: 'hh', pattern: Array(steps).fill(false), modifiers: {} },
   ]).map((row) => {
     // Type guard for modifiers property
     return {
       ...row,
+      pattern: Array.isArray(row.pattern) && row.pattern.length === steps ? row.pattern : Array(steps).fill(false),
       modifiers: typeof (row as any).modifiers === 'object' ? (row as any).modifiers : {},
     };
   });
+
+  // Step counter handlers
+  const setSteps = (newSteps: number) => {
+    if (newSteps < 1 || newSteps > 32) return;
+    // Adjust all row patterns to new length
+    const newRows = rows.map((row) => {
+      let newPattern = row.pattern.slice(0, newSteps);
+      if (newPattern.length < newSteps) {
+        newPattern = newPattern.concat(Array(newSteps - newPattern.length).fill(false));
+      }
+      // Remove modifiers for steps that no longer exist
+      const newModifiers: { [stepIdx: number]: CellState } = {};
+      Object.entries(row.modifiers).forEach(([k, v]) => {
+        const idx = Number(k);
+        if (idx < newSteps) newModifiers[idx] = v as CellState;
+      });
+      return { ...row, pattern: newPattern, modifiers: newModifiers };
+    });
+    updateNodeData(id, { steps: newSteps, rows: newRows });
+  };
+
+  // Track counter handlers
+  const addTrack = () => {
+    const newRows = [
+      ...rows,
+      {
+        instrument: DRUM_OPTIONS[0] || 'bd',
+        pattern: Array(steps).fill(false),
+        modifiers: {},
+      },
+    ];
+    updateNodeData(id, { rows: newRows });
+  };
+  const removeTrack = () => {
+    if (rows.length <= 1) return;
+    const newRows = rows.slice(0, -1);
+    updateNodeData(id, { rows: newRows });
+  };
+
+  // Modifier toggle handler
+  const setModifiersEnabled = (enabled: boolean) => {
+    updateNodeData(id, { modifiersEnabled: enabled });
+  };
 
   const toggleStep = (rowIndex: number, step: number) => {
     const newRows = rows.map((row, rIndex) => {
@@ -162,40 +211,19 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
     updateNodeData(id, { rows: newRows });
   };
 
-
   const clearAll = () => {
     const newRows = rows.map((row) => ({
       ...row,
-      pattern: Array(16).fill(false),
+      pattern: Array(steps).fill(false),
       modifiers: {},
     }));
-    updateNodeData(id, { rows: newRows });
-  };
-
-
-  const addTrack = () => {
-    // Use latest rows from current closure
-    const newRows = [
-      ...rows,
-      {
-        instrument: DRUM_OPTIONS[0] || 'bd',
-        pattern: Array(16).fill(false),
-        modifiers: {},
-      },
-    ];
-    updateNodeData(id, { rows: newRows });
-  };
-
-  // Remove the last track (if more than one)
-  const removeTrack = () => {
-    if (rows.length <= 1) return;
-    const newRows = rows.slice(0, -1);
     updateNodeData(id, { rows: newRows });
   };
 
   return (
     <WorkflowNode id={id} data={data} type={type}>
       <div className="flex flex-col gap-3 p-3 bg-card text-card-foreground rounded-md min-w-96">
+        {/* Sequencer rows */}
         <div className="flex flex-col gap-2 p-3 rounded border">
           {rows.map((row, index) => (
             <SequencerRow
@@ -205,10 +233,11 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
               onStepClick={toggleStep}
               onInstrumentChange={handleInstrumentChange}
               onModifierSelect={handleModifierSelect}
+              showModifiers={modifiersEnabled}
             />
           ))}
         </div>
-        <div className="flex flex-wrap gap-2 items-center justify-between">
+        <div className="flex flex-wrap gap-4 items-center justify-between mt-2">
           <div className="flex gap-2">
             <Button
               variant="outline"
@@ -218,23 +247,64 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
             >
               Clear All
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={addTrack}
-              className="text-xs"
-            >
-              + Add Track
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={removeTrack}
-              className="text-xs"
-              disabled={rows.length <= 1}
-            >
-              Remove Track
-            </Button>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-xs">Steps</span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 w-6 px-0 text-xs"
+                onClick={() => setSteps(steps - 1)}
+                disabled={steps <= 1}
+                aria-label="Decrease steps"
+              >
+                -
+              </Button>
+              <span className="text-xs w-5 text-center">{steps}</span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 w-6 px-0 text-xs"
+                onClick={() => setSteps(steps + 1)}
+                disabled={steps >= 32}
+                aria-label="Increase steps"
+              >
+                +
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs">Tracks</span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 w-6 px-0 text-xs"
+                onClick={removeTrack}
+                disabled={rows.length <= 1}
+                aria-label="Remove track"
+              >
+                -
+              </Button>
+              <span className="text-xs w-5 text-center">{rows.length}</span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 w-6 px-0 text-xs"
+                onClick={addTrack}
+                aria-label="Add track"
+              >
+                +
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs">Modifiers</span>
+              <Switch
+                checked={modifiersEnabled}
+                onCheckedChange={setModifiersEnabled}
+                aria-label="Toggle modifiers"
+                className="scale-75"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -244,19 +314,22 @@ export function BeatMachineNode({ id, data, type }: WorkflowNodeProps) {
 
 BeatMachineNode.strudelOutput = (node: AppNode, strudelString: string) => {
   const data = node.data;
+  const modifiersEnabled = typeof data.modifiersEnabled === 'boolean' ? data.modifiersEnabled : false;
+  const steps = typeof data.steps === 'number' ? data.steps : 16;
   const rows = data.rows || [
-    { instrument: 'bd', pattern: Array(16).fill(false), modifiers: {} },
-    { instrument: 'sd', pattern: Array(16).fill(false), modifiers: {} },
-    { instrument: 'hh', pattern: Array(16).fill(false), modifiers: {} },
+    { instrument: 'bd', pattern: Array(steps).fill(false), modifiers: {} },
+    { instrument: 'sd', pattern: Array(steps).fill(false), modifiers: {} },
+    { instrument: 'hh', pattern: Array(steps).fill(false), modifiers: {} },
   ];
 
+  // If modifiers are disabled, ignore them in output
   const patterns = rows.map(
     (row) =>
-      `sound("${row.instrument}").struct("${patternToString(row.pattern, typeof (row as any).modifiers === 'object' ? (row as any).modifiers : {})}")`
+      `sound("${row.instrument}").struct("${patternToString(row.pattern, modifiersEnabled ? (typeof (row as any).modifiers === 'object' ? (row as any).modifiers : {}) : {})}")`
   );
 
   const validPatterns = patterns.filter(
-    (p) => !p.includes(Array(16).fill('~').join(''))
+    (p) => !p.includes(Array(steps).fill('~').join(''))
   );
 
   if (validPatterns.length === 0) {

--- a/src/components/nodes/instruments/pad-node.tsx
+++ b/src/components/nodes/instruments/pad-node.tsx
@@ -196,8 +196,13 @@ PadNode.strudelOutput = (node: AppNode, strudelString: string) => {
     return stepPattern;
   };
 
-  const stepPatterns = grid.map(generateStepPattern).filter(Boolean);
-  const pattern = stepPatterns.join(' ');
+  // Only use the first `steps` rows of the grid
+  const steps = data.steps || 5;
+  const stepPatternsWithEmpty = grid.slice(0, steps).map((row, stepIdx) => {
+    const step = generateStepPattern(row, stepIdx);
+    return step === '' ? '[~]' : step;
+  });
+  const pattern = stepPatternsWithEmpty.join(' ');
 
   if (!pattern || !pattern.trim() || /^[~\s]*$/.test(pattern.trim())) {
     return strudelString;

--- a/src/components/nodes/instruments/pad-utils/modifiers.tsx
+++ b/src/components/nodes/instruments/pad-utils/modifiers.tsx
@@ -8,8 +8,8 @@ import {
 // Simple type - just track what modifier is selected
 export type CellState = { type: 'off' } | { type: 'modifier'; value: string }; // value like "!2", "/3", "@4", "*2"
 
-// Simple options grouped by type
-const MODIFIER_GROUPS = {
+// Default modifier groups (used by all nodes unless overridden)
+const DEFAULT_MODIFIER_GROUPS = {
   Replicate: [
     { value: '!2', label: '!2' },
     { value: '!3', label: '!3' },
@@ -35,11 +35,13 @@ const MODIFIER_GROUPS = {
 export interface ModifierDropdownProps {
   currentState: CellState;
   onModifierSelect: (modifier: CellState) => void;
+  modifierGroups?: Record<string, { value: string; label: string }[]>;
 }
 
 export function ModifierDropdown({
   currentState,
   onModifierSelect,
+  modifierGroups,
 }: ModifierDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -73,7 +75,7 @@ export function ModifierDropdown({
             None
           </button>
 
-          {Object.entries(MODIFIER_GROUPS).map(([groupName, modifiers]) => (
+          {Object.entries(modifierGroups || DEFAULT_MODIFIER_GROUPS).map(([groupName, modifiers]) => (
             <div key={groupName} className="border-t pt-2">
               <div className="text-xs font-medium text-muted-foreground px-2 mb-1">
                 {groupName}

--- a/src/components/nodes/instruments/pad-utils/pad-button.tsx
+++ b/src/components/nodes/instruments/pad-utils/pad-button.tsx
@@ -12,6 +12,7 @@ interface PadButtonProps {
     noteIdx: number,
     event?: React.MouseEvent
   ) => void;
+  className?: string;
 }
 
 export const PadButton: React.FC<PadButtonProps> = ({
@@ -21,6 +22,7 @@ export const PadButton: React.FC<PadButtonProps> = ({
   isSelected,
   noteGroups,
   toggleCell,
+  className = '',
 }) => {
   const groupIndex = getButtonGroupIndex(stepIdx, noteIdx, noteGroups);
   const isInGroup = groupIndex >= 0;
@@ -30,7 +32,7 @@ export const PadButton: React.FC<PadButtonProps> = ({
     isInGroup,
     groupIndex,
     on
-  )} w-12 h-10`;
+  )} w-12 h-10 ${className}`;
 
   return (
     <button

--- a/src/components/nodes/synths/synth-select-node.tsx
+++ b/src/components/nodes/synths/synth-select-node.tsx
@@ -21,7 +21,7 @@ export function SynthSelectNode({ id, data }: WorkflowNodeProps) {
   // Example synth categories (adjust as needed for your actual sounds)
   const synthCategories = [
     { label: 'Bass', options: ['bass', 'bass0', 'bass1', 'bass2', 'bass3', 'bassdm', 'bassfoo', 'jungbass', 'jvbass', 'moog'] },
-    { label: 'Leads', options: ['arp', 'arpy', 'lead', 'hoover', 'juno', 'saw', 'stab', 'simplesine', 'sine', 'pluck'] },
+    { label: 'Leads', options: ['tri','square','arp', 'arpy', 'lead', 'hoover', 'juno', 'saw', 'stab', 'simplesine', 'sine', 'pluck'] },
     { label: 'Pads', options: ['pad', 'padlong', 'space', 'newnotes', 'notes'] },
     { label: 'FX & Other', options: SOUND_OPTIONS.filter((s) => !['bass', 'bass0', 'bass1', 'bass2', 'bass3', 'bassdm', 'bassfoo', 'jungbass', 'jvbass', 'moog', 'arp', 'arpy', 'lead', 'hoover', 'juno', 'saw', 'stab', 'simplesine', 'sine', 'pluck', 'pad', 'padlong', 'space', 'newnotes', 'notes'].includes(s)) },
   ];

--- a/src/components/nodes/synths/synth-select-node.tsx
+++ b/src/components/nodes/synths/synth-select-node.tsx
@@ -18,6 +18,14 @@ export function SynthSelectNode({ id, data }: WorkflowNodeProps) {
     updateNodeData(id, { sound: value });
   };
 
+  // Example synth categories (adjust as needed for your actual sounds)
+  const synthCategories = [
+    { label: 'Bass', options: ['bass', 'bass0', 'bass1', 'bass2', 'bass3', 'bassdm', 'bassfoo', 'jungbass', 'jvbass', 'moog'] },
+    { label: 'Leads', options: ['arp', 'arpy', 'lead', 'hoover', 'juno', 'saw', 'stab', 'simplesine', 'sine', 'pluck'] },
+    { label: 'Pads', options: ['pad', 'padlong', 'space', 'newnotes', 'notes'] },
+    { label: 'FX & Other', options: SOUND_OPTIONS.filter((s) => !['bass', 'bass0', 'bass1', 'bass2', 'bass3', 'bassdm', 'bassfoo', 'jungbass', 'jvbass', 'moog', 'arp', 'arpy', 'lead', 'hoover', 'juno', 'saw', 'stab', 'simplesine', 'sine', 'pluck', 'pad', 'padlong', 'space', 'newnotes', 'notes'].includes(s)) },
+  ];
+
   return (
     <WorkflowNode id={id} data={data}>
       <div className="flex flex-col gap-2 p-3">
@@ -26,10 +34,13 @@ export function SynthSelectNode({ id, data }: WorkflowNodeProps) {
             <SelectValue placeholder="Select Sample" />
           </SelectTrigger>
           <SelectContent>
-            {SOUND_OPTIONS.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
+            {synthCategories.map((cat) => (
+              <div key={cat.label}>
+                <div className="px-2 py-1 text-xs text-muted-foreground font-semibold">{cat.label}</div>
+                {cat.options.map((option) => (
+                  <SelectItem key={option} value={option}>{option}</SelectItem>
+                ))}
+              </div>
             ))}
           </SelectContent>
         </Select>

--- a/src/data/sound-categories.ts
+++ b/src/data/sound-categories.ts
@@ -1,0 +1,84 @@
+// Utility to categorize drum and synth options for robust UI grouping
+
+export const DRUM_CATEGORIES = [
+  {
+    label: 'Kicks',
+    options: [
+      'bd',
+      'kicklinn',
+      'clubkick',
+      'hardkick',
+      'popkick',
+      'reverbkick',
+    ],
+  },
+  {
+    label: 'Snares',
+    options: [
+      'sd',
+      'dr_few',
+      'drum',
+      'drumtraks',
+      'electro1',
+      'hardcore',
+      'house',
+      'ifdrums',
+      'jungle',
+      'gretsch',
+    ],
+  },
+  {
+    label: 'Hi-Hats',
+    options: ['hh', 'linnhats', 'dr', 'dr2', 'dr55'],
+  },
+  {
+    label: 'Claps',
+    options: ['cp', 'realclaps'],
+  },
+  {
+    label: 'Percussion',
+    options: ['clak', 'click', 'stomp', 'tabla', 'tabla2', 'tablex'],
+  },
+];
+
+// Example synth categories (expand as needed)
+export const SYNTH_CATEGORIES = [
+  {
+    label: 'Bass',
+    options: [
+      'bass',
+      'bass0',
+      'bass1',
+      'bass2',
+      'bass3',
+      'bassdm',
+      'bassfoo',
+      'jungbass',
+      'jvbass',
+      'moog',
+    ],
+  },
+  {
+    label: 'Leads',
+    options: [
+      'arp',
+      'arpy',
+      'lead',
+      'hoover',
+      'juno',
+      'saw',
+      'stab',
+      'simplesine',
+      'sine',
+      'pluck',
+    ],
+  },
+  {
+    label: 'Pads',
+    options: ['pad', 'padlong', 'space', 'newnotes', 'notes'],
+  },
+  {
+    label: 'FX & Other',
+    options: [], // Will be filled dynamically in the component
+  },
+];


### PR DESCRIPTION
I improved both the drum component and the pad component to be more accurate and customizable. 
Pad:
Now lets you have empty cells (Before that empty cells were ignored which made it impossible to make predictable melodies.)
<img width="256" height="316" alt="Screenshot 2026-02-04 at 16 41 32" src="https://github.com/user-attachments/assets/56b831ff-c6bf-488f-9e15-2e6c9e92644d" />


Drums:
Now it's possible to change the amount of tracks per drum component, add time modifiers per cell, and edit the amount of steps, time modifiers are hidden by default and can be turned on if needed in order to simplify the UI
<img width="594" height="230" alt="Screenshot 2026-02-04 at 16 43 57" src="https://github.com/user-attachments/assets/93ebba29-06d8-4b65-aac0-69702e61ae5e" />


<img width="562" height="248" alt="Screenshot 2026-02-04 at 16 50 26" src="https://github.com/user-attachments/assets/00e5cc19-e22c-4256-8c4b-62a49dc6e616" />



Organizing Sample names:
I orginized the sample names and splitted them into categories so that it will be easier to find the sample you need, I know it doesn't really belong in the same category, so I can make a seperate PR for that if needed

<img width="136" height="457" alt="Screenshot 2026-02-04 at 16 48 08" src="https://github.com/user-attachments/assets/732c05ec-fc34-4153-bb68-056b7fb09067" />



<img width="133" height="366" alt="Screenshot 2026-02-04 at 16 48 24" src="https://github.com/user-attachments/assets/db3f84a8-8d4f-46c6-8fc8-d40bf9f74040" />




